### PR TITLE
Corrected requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord>=1.6.0
+discord.py>=1.6.0


### PR DESCRIPTION
**What was fixed:**
The "package" name for discord.py is discord.py not discord.

**Why the error occurred:**
PyCharm can't handle that discord.py is importing discord instead of discord.py.
That's why PyCharm creates a requirements.txt with discord instead of discord.py.

**Error that occurs with wrong requirements.txt:**

`ERROR: Could not find a version that satisfies the requirement discord>=1.6.0`
`ERROR: No matching distribution found for discord>=1.6.0`